### PR TITLE
Add babel/webpack config to support global stylesheets

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,0 +1,14 @@
+{
+  "plugins": [
+    [
+      "wrap-in-js",
+      {
+        "extensions": ["css$", "scss$"]
+      }
+    ]
+  ],
+  "presets": [
+    "next/babel"
+  ],
+  "ignore": []
+}

--- a/next.config.js
+++ b/next.config.js
@@ -1,0 +1,36 @@
+const path = require('path')
+const glob = require('glob')
+
+module.exports = {
+  webpack: (config, { dev }) => {
+    config.module.rules.push(
+      {
+        test: /\.(css|scss)/,
+        loader: 'emit-file-loader',
+        options: {
+          name: 'dist/[path][name].[ext]'
+        }
+      }
+    ,
+      {
+        test: /\.css$/,
+        use: ['babel-loader', 'raw-loader', 'postcss-loader']
+      }
+    ,
+      {
+        test: /\.s(a|c)ss$/,
+        use: ['babel-loader', 'raw-loader', 'postcss-loader',
+          { loader: 'sass-loader',
+            options: {
+              includePaths: ['styles', 'node_modules']
+                .map((d) => path.join(__dirname, d))
+                .map((g) => glob.sync(g))
+                .reduce((a, c) => a.concat(c), [])
+            }
+          }
+        ]
+      }
+    )
+    return config
+  }
+}

--- a/package.json
+++ b/package.json
@@ -2,10 +2,20 @@
   "name": "mentor-weekly",
   "private": true,
   "dependencies": {
+    "autoprefixer": "^7.2.4",
+    "babel-plugin-module-resolver": "^3.0.0",
+    "babel-plugin-wrap-in-js": "^1.1.1",
     "express": "^4.16.2",
+    "glob": "^7.1.2",
     "next": "^4.2.1",
+    "node-sass": "^4.7.2",
+    "normalize.css": "^7.0.0",
+    "postcss-easy-import": "^3.0.0",
+    "postcss-loader": "^2.0.10",
+    "raw-loader": "^0.5.1",
     "react": "^16.2.0",
-    "react-dom": "^16.2.0"
+    "react-dom": "^16.2.0",
+    "sass-loader": "^6.0.6"
   },
   "devDependencies": {
     "babel-eslint": "7.0.0",

--- a/pages/_document.js
+++ b/pages/_document.js
@@ -1,0 +1,25 @@
+import Document, { Head, Main, NextScript } from 'next/document'
+import flush from 'styled-jsx/server'
+import stylesheet from '../styles/application.scss'
+
+export default class MyDocument extends Document {
+  static getInitialProps({ renderPage }) {
+    const { html, head, errorHtml, chunks } = renderPage()
+    const styles = flush()
+    return { html, head, errorHtml, chunks, styles }
+  }
+
+  render() {
+    return (
+      <html>
+        <Head>
+          <style dangerouslySetInnerHTML={{ __html: stylesheet }} />
+        </Head>
+        <body>
+          <Main />
+          <NextScript />
+        </body>
+      </html>
+    )
+  }
+}

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: [
+    require('postcss-easy-import')({prefix: '_'}), // keep this first
+    require('autoprefixer')({ /* ...options */ }) // so imports are auto-prefixed too
+  ]
+}

--- a/styles/application.scss
+++ b/styles/application.scss
@@ -1,0 +1,7 @@
+@import 'normalize.css';
+
+$primary-color: black;
+
+body {
+  background-color: blue;
+}


### PR DESCRIPTION
This PR adds support for global stylesheets similar in function to typical web apps.

Code was adapted from this repo: https://github.com/davibe/next.js-example-with-global-stylesheet (thanks @davibe!)

I'd like to get this into master soon for use in @alodahl's frontend branch, but it is probably good to make a note in the Readme on how to add additional stylesheets.